### PR TITLE
View Author Blog Posts

### DIFF
--- a/TabloidCLI/UserInterfaceManagers/AuthorDetailManager.cs
+++ b/TabloidCLI/UserInterfaceManagers/AuthorDetailManager.cs
@@ -74,7 +74,9 @@ namespace TabloidCLI.UserInterfaceManagers
             List<Post> posts = _postRepository.GetByAuthor(_authorId);
             foreach (Post post in posts)
             {
-                Console.WriteLine(post);
+                Console.WriteLine(post.Title);
+                Console.WriteLine(post.Url);
+                Console.WriteLine(post.PublishDateTime);
             }
             Console.WriteLine();
         }


### PR DESCRIPTION
Description
Fixes # (issue)
Added functionality to the Author Management option. You can view blog posts based on the author that wrote them.

Type of change
New feature (non-breaking change which adds functionality)

Testing Instructions

Pull down and checkout the af-author-blogs branch. Run the CLI. Go to Author Management. Select Author Details. Choose the 3rd author, because this is the only author with a blog at the moment. Select View Blog Posts. Repeat with other authors if desired, but you should get no results with other authors. 

Checklist:
My code follows the style guidelines of this project
I have performed a self-review of my own code
I have commented my code, particularly in hard-to-understand areas
My changes generate no new warnings or errors
I have added test instructions that prove my fix is effective or that my feature works